### PR TITLE
(CI) Add flake8 to web and box to get unified linting

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Check for linting before running tests
+      uses: py-actions/flake8@v2
     - name: Build, run, test and tear down
       working-directory: ./washee_web
       run: |


### PR DESCRIPTION
Add flake8 automatic linter. It is possible to find some VSCode extension or automatic script that converts everything, but i havent checked too much.

Configuration can be done following this link:
https://github.com/marketplace/actions/python-flake8-lint

BEWARE configurations should be identical between web and box, when at all possible.
Also, it is not certain this CI will run on the Web, since no Web code has been changed. MAKE SURE THE CODE IS IN FLAKE8 WHEN MERGING!